### PR TITLE
Replace footer image with .png file

### DIFF
--- a/tenants/all/config/brands.js
+++ b/tenants/all/config/brands.js
@@ -2,7 +2,7 @@ module.exports = {
   nrwa: {
     brandName: 'National Rural Water Association',
     headerSrc: '/files/base/roguemonkeymedia/all/image/static/nrwa/RuralWaterWire-1200x454.png',
-    logoSrc: '/files/base/roguemonkeymedia/all/image/static/nrwa/Rural-Water-Wire_rev-logo.svg',
+    logoSrc: '/files/base/roguemonkeymedia/all/image/static/nrwa/rural-water-wire-logo-white.png',
     advertiseLink: 'https://content.nrwa.org/page/advertise',
     contactUsLink: 'https://content.nrwa.org/page/contact-us',
     bgColor: '#3856a6',


### PR DESCRIPTION
—fixes broken image & blown out footer from recent Windows Outlook update

<img width="686" alt="Screen Shot 2022-04-21 at 8 28 04 AM" src="https://user-images.githubusercontent.com/64623209/164468949-36c466bd-c7e0-423d-80cf-c3af63c358a6.png">
